### PR TITLE
Streaming TTS (#38) and replay command (#40)

### DIFF
--- a/software/mac/claude_runner.py
+++ b/software/mac/claude_runner.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 from pathlib import Path
+from typing import AsyncIterator
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +14,37 @@ SYSTEM_PROMPT = (
     "no code blocks, no lists. Be conversational and concise. "
     "If asked for code or detailed info, give a brief spoken summary only."
 )
+
+
+def _extract_text(obj: dict) -> list[str]:
+    """Pull assistant text out of a stream-json event. Tolerant of schema drift."""
+    if not isinstance(obj, dict):
+        return []
+    out: list[str] = []
+    # Final result event has full text in `result`.
+    if obj.get("type") == "result" and isinstance(obj.get("result"), str):
+        # Only emit result text if no prior assistant chunks emitted it. Caller
+        # de-dupes by accumulating; we skip result here since assistant events
+        # already carry the text.
+        return []
+    # Assistant events: message.content[*].text
+    msg = obj.get("message")
+    if isinstance(msg, dict):
+        content = msg.get("content")
+        if isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        out.append(text)
+    # Partial-message events (when --include-partial-messages is set):
+    # event.delta.text
+    delta = obj.get("delta")
+    if isinstance(delta, dict):
+        text = delta.get("text")
+        if isinstance(text, str):
+            out.append(text)
+    return out
 
 
 class ClaudeRunner:
@@ -71,47 +103,76 @@ class ClaudeRunner:
         return "\n".join(parts)
 
     async def run(self, prompt: str, timeout: float = 60.0) -> str:
-        """Run Claude Code with conversation context.
+        """Run Claude Code with conversation context. Returns full response."""
+        chunks: list[str] = []
+        async for chunk in self.run_stream(prompt, timeout=timeout):
+            chunks.append(chunk)
+        response = "".join(chunks).strip()
+        self._record(prompt, response)
+        return response
 
-        Maintains a rolling history of the last MAX_HISTORY exchanges
-        so Claude has context from previous voice interactions.
+    async def run_stream(
+        self, prompt: str, timeout: float = 60.0
+    ) -> AsyncIterator[str]:
+        """Run Claude Code and yield text chunks as they arrive.
+
+        Caller is responsible for accumulating the full response. History is
+        NOT saved here — call _record() after consuming the stream.
         """
         full_prompt = self._build_prompt(prompt)
-        logger.debug("Running Claude with prompt (%d chars, %d history entries)",
-                      len(full_prompt), len(self._history))
+        logger.debug("Running Claude (stream) with prompt (%d chars, %d history)",
+                     len(full_prompt), len(self._history))
 
         proc = await asyncio.create_subprocess_exec(
             "claude",
             "-p",
             "--output-format",
-            "text",
+            "stream-json",
+            "--verbose",
             "--dangerously-skip-permissions",
             full_prompt,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
 
+        async def read_lines() -> AsyncIterator[str]:
+            assert proc.stdout is not None
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    return
+                text = line.decode("utf-8", errors="replace").strip()
+                if not text:
+                    continue
+                try:
+                    obj = json.loads(text)
+                except json.JSONDecodeError:
+                    logger.debug("Skipping non-JSON line: %r", text[:80])
+                    continue
+                for piece in _extract_text(obj):
+                    if piece:
+                        yield piece
+
         try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            async with asyncio.timeout(timeout):
+                async for piece in read_lines():
+                    yield piece
+                rc = await proc.wait()
         except asyncio.TimeoutError:
             proc.kill()
             await proc.wait()
             raise RuntimeError(f"Claude timed out after {timeout}s")
 
-        if proc.returncode != 0:
+        if rc != 0:
+            stderr = await proc.stderr.read() if proc.stderr else b""
             err_msg = stderr.decode("utf-8", errors="replace").strip()
-            raise RuntimeError(f"Claude exited with code {proc.returncode}: {err_msg}")
+            raise RuntimeError(f"Claude exited with code {rc}: {err_msg}")
 
-        response = stdout.decode("utf-8", errors="replace").strip()
-        logger.debug("Claude response length: %d chars", len(response))
-
-        # Save to history
+    def _record(self, prompt: str, response: str) -> None:
         self._history.append({"user": prompt, "assistant": response})
         if len(self._history) > self._max_history:
             self._history = self._history[-self._max_history:]
         self._save_history()
-
-        return response
 
     def clear_history(self) -> None:
         """Reset conversation history and delete the history file."""

--- a/software/mac/orchestrator.py
+++ b/software/mac/orchestrator.py
@@ -22,6 +22,22 @@ EDGE_VOICES = [
     ("en-AU-WilliamNeural", "William (Australian male)"),
 ]
 
+REPLAY_PHRASES = [
+    "repeat that",
+    "say that again",
+    "what did you say",
+    "say it again",
+    "repeat",
+]
+
+
+def _normalize(text: str) -> str:
+    cleaned = "".join(c for c in text.lower() if c.isalnum() or c.isspace())
+    return " ".join(cleaned.split())
+
+
+_NORMALIZED_REPLAY_PHRASES = {_normalize(p) for p in REPLAY_PHRASES}
+
 
 class ClodOrchestrator:
     """Mac-side voice pipeline: mic -> STT -> Claude Code -> TTS -> speaker.
@@ -43,6 +59,21 @@ class ClodOrchestrator:
             if voice_id == self._tts._voice:
                 self._voice_index = i
                 break
+        self._last_response: str | None = None
+
+    async def _replay_last(self) -> None:
+        if self._last_response is None:
+            print("  Nothing to replay yet.")
+            await self._set_state("idle")
+            return
+        print(f"  Replaying: {self._last_response}")
+        await self._set_state("speaking")
+        try:
+            await self._tts.speak(self._apply_speech_mode(self._last_response))
+        except Exception as exc:
+            await self._handle_error("TTS failed", exc)
+            return
+        await self._set_state("idle")
 
     async def _set_state(self, state: str) -> None:
         """Update the Pi display and print the state to the terminal."""
@@ -89,7 +120,7 @@ class ClodOrchestrator:
         try:
             while True:
                 mode_label = f" [{self._speech_mode} mode]" if self._speech_mode != "normal" else ""
-                print(f"Enter=speak{mode_label} | 'theme' | 'voice' | 'rocky'/'normal'")
+                print(f"Enter=speak{mode_label} | 'theme' | 'voice' | 'rocky'/'normal' | 'clear' | 'replay'")
                 user_input = await self._wait_for_input()
 
                 # Handle commands
@@ -112,6 +143,9 @@ class ClodOrchestrator:
                 elif user_input == "clear":
                     self._claude.clear_history()
                     print("  Conversation history cleared.")
+                    continue
+                elif user_input == "replay":
+                    await self._replay_last()
                     continue
                 elif user_input == "voice":
                     self._voice_index = (self._voice_index + 1) % len(EDGE_VOICES)
@@ -171,6 +205,9 @@ class ClodOrchestrator:
 
                 # Check for voice commands before sending to Claude
                 lower = transcript.lower().strip()
+                if _normalize(transcript) in _NORMALIZED_REPLAY_PHRASES:
+                    await self._replay_last()
+                    continue
                 if any(phrase in lower for phrase in [
                     "switch theme", "next theme", "change theme",
                     "switch the theme", "change the theme",
@@ -192,6 +229,8 @@ class ClodOrchestrator:
                 except Exception as exc:
                     await self._handle_error("Claude failed", exc)
                     continue
+
+                self._last_response = response
 
                 # Step 5: Apply speech mode transformation
                 spoken_text = self._apply_speech_mode(response)

--- a/software/mac/orchestrator.py
+++ b/software/mac/orchestrator.py
@@ -9,7 +9,7 @@ from mac.claude_runner import ClaudeRunner
 from mac.pi_client import PiClient
 from mac.rocky_transform import rocky_transform
 from mac.stt import SpeechToText
-from mac.tts import TextToSpeech
+from mac.tts import TextToSpeech, split_sentences
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +46,19 @@ class ClodOrchestrator:
     Supports speech modes: 'normal' and 'rocky'.
     """
 
-    def __init__(self, pi_host: str = "clod.local", pi_port: int = 9999) -> None:
+    def __init__(
+        self,
+        pi_host: str = "clod.local",
+        pi_port: int = 9999,
+        streaming_tts: bool = True,
+    ) -> None:
         self._pi = PiClient(host=pi_host, port=pi_port)
         self._recorder = AudioRecorder()
         self._stt = SpeechToText()
         self._claude = ClaudeRunner()
         self._tts = TextToSpeech(voice="en-GB-RyanNeural")
         self._speech_mode: str = "normal"  # "normal" or "rocky"
+        self._streaming_tts = streaming_tts
         # Determine initial voice index from current TTS voice
         self._voice_index: int = 0
         for i, (voice_id, _) in enumerate(EDGE_VOICES):
@@ -60,6 +66,35 @@ class ClodOrchestrator:
                 self._voice_index = i
                 break
         self._last_response: str | None = None
+
+    async def _stream_and_speak(self, transcript: str) -> str:
+        """Stream Claude's response, splitting on sentence boundaries and
+        speaking each sentence as soon as it arrives. Returns the full raw
+        Claude response (pre-speech-mode transform), and records it to history.
+        """
+        raw_chunks: list[str] = []
+
+        async def claude_chunks():
+            async for chunk in self._claude.run_stream(transcript):
+                raw_chunks.append(chunk)
+                yield chunk
+
+        async def transformed_sentences():
+            async for sentence in split_sentences(claude_chunks()):
+                yield self._apply_speech_mode(sentence)
+
+        async def announce(sentence: str) -> None:
+            if self._speech_mode != "normal":
+                print(f"  Rocky:  {sentence}")
+            else:
+                print(f"  Claude: {sentence}")
+
+        await self._set_state("speaking")
+        await self._tts.speak_stream(transformed_sentences(), on_sentence=announce)
+
+        response = "".join(raw_chunks).strip()
+        self._claude._record(transcript, response)
+        return response
 
     async def _replay_last(self) -> None:
         if self._last_response is None:
@@ -223,31 +258,33 @@ class ClodOrchestrator:
                     await self._set_state("idle")
                     continue
 
-                # Step 4: Send to Claude
-                try:
-                    response = await self._claude.run(transcript)
-                except Exception as exc:
-                    await self._handle_error("Claude failed", exc)
-                    continue
+                # Step 4-6: Send to Claude and speak (streaming or batch)
+                if self._streaming_tts:
+                    try:
+                        response = await self._stream_and_speak(transcript)
+                    except Exception as exc:
+                        await self._handle_error("Claude/TTS failed", exc)
+                        continue
+                else:
+                    try:
+                        response = await self._claude.run(transcript)
+                    except Exception as exc:
+                        await self._handle_error("Claude failed", exc)
+                        continue
+                    spoken_text = self._apply_speech_mode(response)
+                    if self._speech_mode != "normal":
+                        print(f"  Claude: {response}")
+                        print(f"  Rocky:  {spoken_text}")
+                    else:
+                        print(f"  Claude: {response}")
+                    await self._set_state("speaking")
+                    try:
+                        await self._tts.speak(spoken_text)
+                    except Exception as exc:
+                        await self._handle_error("TTS failed", exc)
+                        continue
 
                 self._last_response = response
-
-                # Step 5: Apply speech mode transformation
-                spoken_text = self._apply_speech_mode(response)
-
-                if self._speech_mode != "normal":
-                    print(f"  Claude: {response}")
-                    print(f"  Rocky:  {spoken_text}")
-                else:
-                    print(f"  Claude: {response}")
-
-                # Step 6: Speak the response
-                await self._set_state("speaking")
-                try:
-                    await self._tts.speak(spoken_text)
-                except Exception as exc:
-                    await self._handle_error("TTS failed", exc)
-                    continue
 
                 # Step 7: Back to idle
                 await self._set_state("idle")

--- a/software/mac/orchestrator.py
+++ b/software/mac/orchestrator.py
@@ -73,6 +73,7 @@ class ClodOrchestrator:
         Claude response (pre-speech-mode transform), and records it to history.
         """
         raw_chunks: list[str] = []
+        speaking_started = False
 
         async def claude_chunks():
             async for chunk in self._claude.run_stream(transcript):
@@ -84,12 +85,15 @@ class ClodOrchestrator:
                 yield self._apply_speech_mode(sentence)
 
         async def announce(sentence: str) -> None:
+            nonlocal speaking_started
+            if not speaking_started:
+                await self._set_state("speaking")
+                speaking_started = True
             if self._speech_mode != "normal":
                 print(f"  Rocky:  {sentence}")
             else:
                 print(f"  Claude: {sentence}")
 
-        await self._set_state("speaking")
         await self._tts.speak_stream(transformed_sentences(), on_sentence=announce)
 
         response = "".join(raw_chunks).strip()

--- a/software/mac/tts.py
+++ b/software/mac/tts.py
@@ -113,13 +113,14 @@ class TextToSpeech:
     ) -> str:
         """Speak sentences as they arrive. Synth and playback overlap.
 
-        Returns the full concatenated text that was actually spoken (raw, before
-        any per-sentence transformation by ``on_sentence``).
+        ``on_sentence`` is called once per sentence before synthesis starts —
+        callers use it to print/log or transition state on first audio. The
+        callback receives the sentence as passed in (transformations should
+        happen upstream of this iterator).
 
-        ``on_sentence`` is called once per sentence with the raw text *before*
-        synthesis — used by callers to log what's being spoken in real time.
-        If the caller wants per-sentence text transformation (e.g. rocky mode),
-        they should transform sentences upstream before passing them in.
+        Returns the joined sentences for convenience; the caller usually keeps
+        its own raw accumulator since this string reflects whatever was passed
+        in (potentially already transformed).
         """
         if self._voice is None:
             return await self._speak_stream_say(sentences, on_sentence)

--- a/software/mac/tts.py
+++ b/software/mac/tts.py
@@ -5,9 +5,29 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import tempfile
+from typing import AsyncIterator, Awaitable, Callable
 
 logger = logging.getLogger(__name__)
+
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+
+
+async def split_sentences(chunks: AsyncIterator[str]) -> AsyncIterator[str]:
+    """Yield complete sentences from an async stream of text chunks."""
+    buf = ""
+    async for chunk in chunks:
+        buf += chunk
+        parts = _SENTENCE_BOUNDARY.split(buf)
+        for part in parts[:-1]:
+            stripped = part.strip()
+            if stripped:
+                yield stripped
+        buf = parts[-1]
+    tail = buf.strip()
+    if tail:
+        yield tail
 
 
 class TextToSpeech:
@@ -50,28 +70,117 @@ class TextToSpeech:
 
     async def _speak_edge(self, text: str) -> None:
         """Speak using Edge TTS — generates audio file then plays it."""
+        tmp_path = await self._synth_edge(text)
+        try:
+            await self._play(tmp_path)
+        finally:
+            self._unlink(tmp_path)
+
+    async def _synth_edge(self, text: str) -> str:
+        """Synthesize text to a temp mp3 file via Edge TTS. Returns path."""
         import edge_tts
 
         tmp = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
         tmp_path = tmp.name
         tmp.close()
-
         try:
             communicate = edge_tts.Communicate(text, self._voice)
             await communicate.save(tmp_path)
+        except Exception:
+            self._unlink(tmp_path)
+            raise
+        return tmp_path
 
-            # Play the audio file
-            proc = await asyncio.create_subprocess_exec(
-                "afplay", tmp_path,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await proc.communicate()
-        finally:
+    async def _play(self, path: str) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            "afplay", path,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.communicate()
+
+    @staticmethod
+    def _unlink(path: str) -> None:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+    async def speak_stream(
+        self,
+        sentences: AsyncIterator[str],
+        on_sentence: Callable[[str], Awaitable[None]] | None = None,
+    ) -> str:
+        """Speak sentences as they arrive. Synth and playback overlap.
+
+        Returns the full concatenated text that was actually spoken (raw, before
+        any per-sentence transformation by ``on_sentence``).
+
+        ``on_sentence`` is called once per sentence with the raw text *before*
+        synthesis — used by callers to log what's being spoken in real time.
+        If the caller wants per-sentence text transformation (e.g. rocky mode),
+        they should transform sentences upstream before passing them in.
+        """
+        if self._voice is None:
+            return await self._speak_stream_say(sentences, on_sentence)
+
+        queue: asyncio.Queue[tuple[str, str] | None] = asyncio.Queue(maxsize=2)
+        spoken: list[str] = []
+        synth_failed: list[Exception] = []
+
+        async def producer() -> None:
             try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
+                async for sentence in sentences:
+                    if not sentence:
+                        continue
+                    spoken.append(sentence)
+                    if on_sentence is not None:
+                        await on_sentence(sentence)
+                    try:
+                        path = await self._synth_edge(sentence)
+                    except Exception as exc:
+                        synth_failed.append(exc)
+                        await queue.put(("say", sentence))
+                        continue
+                    await queue.put(("file", path))
+            finally:
+                await queue.put(None)
+
+        async def consumer() -> None:
+            while True:
+                item = await queue.get()
+                if item is None:
+                    return
+                kind, payload = item
+                if kind == "file":
+                    try:
+                        await self._play(payload)
+                    finally:
+                        self._unlink(payload)
+                else:
+                    await self._speak_say(payload)
+
+        await asyncio.gather(producer(), consumer())
+
+        if synth_failed:
+            logger.warning("Edge TTS failed on %d sentence(s); used say fallback",
+                           len(synth_failed))
+        return " ".join(spoken)
+
+    async def _speak_stream_say(
+        self,
+        sentences: AsyncIterator[str],
+        on_sentence: Callable[[str], Awaitable[None]] | None,
+    ) -> str:
+        spoken: list[str] = []
+        async for sentence in sentences:
+            if not sentence:
+                continue
+            spoken.append(sentence)
+            if on_sentence is not None:
+                await on_sentence(sentence)
+            await self._speak_say(sentence)
+        return " ".join(spoken)
 
     async def _speak_say(self, text: str) -> None:
         """Fallback: speak using macOS say command."""


### PR DESCRIPTION
## Summary
- **#38 Streaming TTS** — Claude invocation switched to `--output-format stream-json --verbose`. New `ClaudeRunner.run_stream()` yields text chunks; `TextToSpeech.speak_stream()` overlaps Edge TTS synthesis and `afplay` playback via a bounded queue (size 2). First sentence speaks while the rest is still generating. Gated by `streaming_tts=True` (default on); batch path preserved as fallback.
- **#40 Replay command** — Typed `replay` and voice phrases (`repeat that`, `say that again`, `what did you say`, `say it again`, `repeat`) re-speak the last response without re-querying Claude. Cache stores raw output so replay re-applies the current speech mode.
- Eye stays in `thinking` state until first audio actually starts (state transition deferred via `on_sentence` callback).

## Test plan
- [ ] Smoke: `claude -p --output-format stream-json --verbose "say hi in two sentences"` — confirm output schema matches `_extract_text` (assistant.message.content[].text or delta.text). If text only appears in `result` events, `claude_runner.py:25-29` needs the result fallback re-enabled.
- [ ] End-to-end on Mac: ask Clod a multi-sentence question, verify first sentence starts speaking before generation completes.
- [ ] Replay: type `replay`, then say "repeat that" — both should re-speak last response.
- [ ] Toggle `streaming_tts=False` in `ClodOrchestrator(...)` and confirm batch path still works.
- [ ] Rocky mode + streaming: confirm per-sentence rocky transform sounds correct (verified safe in review — `rocky_transform` already splits sentences internally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)